### PR TITLE
Refactor (dockerfile): Use debconf-set-selections only for libguestfs-tools

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -16,23 +16,22 @@ RUN buildDeps="gnupg2 curl software-properties-common" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install basic tools. Prevent apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install basic tools
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo ca-certificates wget curl git rsync \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tools for .vhd, .vmdk
+# Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update \
     && apt-get install --no-install-recommends -y libguestfs-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install tools for .iso.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install tools for .iso
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo isolinux squashfs-tools xorriso mkisofs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/variants/1.7.7-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-ubuntu-18.04/Dockerfile
@@ -15,23 +15,22 @@ RUN buildDeps="gnupg2 curl software-properties-common" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install basic tools. Prevent apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install basic tools
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo ca-certificates wget curl git rsync \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tools for .vhd, .vmdk
+# Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update \
     && apt-get install --no-install-recommends -y libguestfs-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install tools for .iso.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install tools for .iso
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo isolinux squashfs-tools xorriso mkisofs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/variants/1.7.7-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-ubuntu-20.04/Dockerfile
@@ -15,23 +15,22 @@ RUN buildDeps="gnupg2 curl software-properties-common" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install basic tools. Prevent apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install basic tools
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo ca-certificates wget curl git rsync \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tools for .vhd, .vmdk
+# Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update \
     && apt-get install --no-install-recommends -y libguestfs-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install tools for .iso.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install tools for .iso
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo isolinux squashfs-tools xorriso mkisofs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/variants/1.7.7-virtualbox-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-ubuntu-18.04/Dockerfile
@@ -15,23 +15,22 @@ RUN buildDeps="gnupg2 curl software-properties-common" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install basic tools. Prevent apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install basic tools
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo ca-certificates wget curl git rsync \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tools for .vhd, .vmdk
+# Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update \
     && apt-get install --no-install-recommends -y libguestfs-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install tools for .iso.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install tools for .iso
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo isolinux squashfs-tools xorriso mkisofs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/variants/1.7.7-virtualbox-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-ubuntu-20.04/Dockerfile
@@ -15,23 +15,22 @@ RUN buildDeps="gnupg2 curl software-properties-common" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install basic tools. Prevent apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install basic tools
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo ca-certificates wget curl git rsync \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tools for .vhd, .vmdk
+# Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update \
     && apt-get install --no-install-recommends -y libguestfs-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install tools for .iso.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Install tools for .iso
+RUN apt-get update \
     && apt-get install --no-install-recommends -y sudo isolinux squashfs-tools xorriso mkisofs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #9

`libguestfs-tools` in partifular requires interaction to configure `tzdata`. The interactive pause can cause the job to never end until the runner timeouts the job.

```
#9 26.48 Setting up libusbredirparser1:amd64 (0.8.0-1) ...
#9 26.48 Setting up libldap-common (2.4.49+dfsg-2ubuntu1.8) ...
#9 26.49 Setting up syslinux (3:6.04~git20190206.bf6db5b4+dfsg1-2) ...
#9 26.49 Setting up libboost-iostreams1.71.0:amd64 (1.71.0-6ubuntu6) ...
#9 26.50 Setting up libjbig0:amd64 (2.1-3.1build1) ...
#9 26.50 Setting up ntfs-3g (1:2017.3.23AR.3-3ubuntu1.1) ...
#9 26.50 Setting up libjansson4:amd64 (2.12-1build1) ...
#9 26.51 Setting up acl (2.2.53-6) ...
#9 26.51 Setting up libkrb5support0:amd64 (1.17-6ubuntu4.1) ...
#9 26.52 Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg-2) ...
#9 26.52 Setting up tzdata (2021e-0ubuntu0.20.04) ...
#9 26.61 debconf: unable to initialize frontend: Dialog
#9 26.61 debconf: (TERM is not set, so the dialog frontend is not usable.)
#9 26.61 debconf: falling back to frontend: Readline
#9 26.65 Configuring tzdata
#9 26.65 ------------------
#9 26.65
#9 26.65 Please select the geographic area in which you live. Subsequent configuration
#9 26.65 questions will narrow this down by presenting a list of cities, representing
#9 26.65 the time zones in which they are located.
#9 26.65
#9 26.65   1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
#9 26.65   2. America     5. Arctic     8. Europe    11. SystemV
#9 26.65   3. Antarctica  6. Asia       9. Indian    12. US
#9 26.65 Geographic area:
```

The fix `echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections` is now applied only to wheh installing `libguestfs-tools`.