### PR TITLE
Fix (tools): Add `linux-image-generic` package for guestmount in all variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -24,9 +24,14 @@ RUN apt-get update \
 
 # Install tools for .vhd, .vmdk
 # Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)': https://github.com/steigr/docker-hipchat-server/issues/1
+RUN apt-get update \
+    \
+    && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get install --no-install-recommends -y libguestfs-tools \
+    \
+    && apt-get install --no-install-recommends -y linux-image-generic \
+    \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/variants/1.7.7-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-ubuntu-18.04/Dockerfile
@@ -23,9 +23,14 @@ RUN apt-get update \
 
 # Install tools for .vhd, .vmdk
 # Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)': https://github.com/steigr/docker-hipchat-server/issues/1
+RUN apt-get update \
+    \
+    && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get install --no-install-recommends -y libguestfs-tools \
+    \
+    && apt-get install --no-install-recommends -y linux-image-generic \
+    \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/variants/1.7.7-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-ubuntu-20.04/Dockerfile
@@ -23,9 +23,14 @@ RUN apt-get update \
 
 # Install tools for .vhd, .vmdk
 # Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)': https://github.com/steigr/docker-hipchat-server/issues/1
+RUN apt-get update \
+    \
+    && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get install --no-install-recommends -y libguestfs-tools \
+    \
+    && apt-get install --no-install-recommends -y linux-image-generic \
+    \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/variants/1.7.7-virtualbox-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-ubuntu-18.04/Dockerfile
@@ -23,9 +23,14 @@ RUN apt-get update \
 
 # Install tools for .vhd, .vmdk
 # Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)': https://github.com/steigr/docker-hipchat-server/issues/1
+RUN apt-get update \
+    \
+    && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get install --no-install-recommends -y libguestfs-tools \
+    \
+    && apt-get install --no-install-recommends -y linux-image-generic \
+    \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/variants/1.7.7-virtualbox-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-ubuntu-20.04/Dockerfile
@@ -23,9 +23,14 @@ RUN apt-get update \
 
 # Install tools for .vhd, .vmdk
 # Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update \
+# Fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)': https://github.com/steigr/docker-hipchat-server/issues/1
+RUN apt-get update \
+    \
+    && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get install --no-install-recommends -y libguestfs-tools \
+    \
+    && apt-get install --no-install-recommends -y linux-image-generic \
+    \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Adds `linux-image-generic` package to fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)'