### PR TITLE
Fix (tools): Install specific mc version in all variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -43,7 +43,7 @@ RUN apt-get update \
 
 # Install tools for storage
 # mc: https://min.io/download#/linux
-RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
+RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-10-07T04-19-58Z > /usr/local/bin/mc \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 

--- a/variants/1.7.7-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-ubuntu-18.04/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
 
 # Install tools for storage
 # mc: https://min.io/download#/linux
-RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
+RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-10-07T04-19-58Z > /usr/local/bin/mc \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 

--- a/variants/1.7.7-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-ubuntu-20.04/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
 
 # Install tools for storage
 # mc: https://min.io/download#/linux
-RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
+RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-10-07T04-19-58Z > /usr/local/bin/mc \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 

--- a/variants/1.7.7-virtualbox-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-ubuntu-18.04/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
 
 # Install tools for storage
 # mc: https://min.io/download#/linux
-RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
+RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-10-07T04-19-58Z > /usr/local/bin/mc \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 

--- a/variants/1.7.7-virtualbox-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-ubuntu-20.04/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
 
 # Install tools for storage
 # mc: https://min.io/download#/linux
-RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
+RUN wget -qO- https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-10-07T04-19-58Z > /usr/local/bin/mc \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 


### PR DESCRIPTION
Newer versions released at https://dl.min.io/client/mc/release/linux-amd64/mc will break builds.