### PR TITLE
Enhancement: Use .deb installer to install a specific virtualbox version

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -139,11 +139,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-1-7-7-virtualbox-ubuntu-20-04:
+  build-1-7-7-virtualbox-6-1-28-ubuntu-20-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 1.7.7-virtualbox-ubuntu-20.04
-      VARIANT_BUILD_DIR: variants/1.7.7-virtualbox-ubuntu-20.04
+      VARIANT_TAG: 1.7.7-virtualbox-6.1.28-ubuntu-20.04
+      VARIANT_BUILD_DIR: variants/1.7.7-virtualbox-6.1.28-ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -393,11 +393,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-1-7-7-virtualbox-ubuntu-18-04:
+  build-1-7-7-virtualbox-6-1-28-ubuntu-18-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 1.7.7-virtualbox-ubuntu-18.04
-      VARIANT_BUILD_DIR: variants/1.7.7-virtualbox-ubuntu-18.04
+      VARIANT_TAG: 1.7.7-virtualbox-6.1.28-ubuntu-18.04
+      VARIANT_BUILD_DIR: variants/1.7.7-virtualbox-6.1.28-ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -521,7 +521,7 @@ jobs:
       if: always()
 
   update-draft-release:
-    needs: [build-1-7-7-ubuntu-20-04, build-1-7-7-virtualbox-ubuntu-20-04, build-1-7-7-ubuntu-18-04, build-1-7-7-virtualbox-ubuntu-18-04]
+    needs: [build-1-7-7-ubuntu-20-04, build-1-7-7-virtualbox-6-1-28-ubuntu-20-04, build-1-7-7-ubuntu-18-04, build-1-7-7-virtualbox-6-1-28-ubuntu-18-04]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -535,7 +535,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-1-7-7-ubuntu-20-04, build-1-7-7-virtualbox-ubuntu-20-04, build-1-7-7-ubuntu-18-04, build-1-7-7-virtualbox-ubuntu-18-04]
+    needs: [build-1-7-7-ubuntu-20-04, build-1-7-7-virtualbox-6-1-28-ubuntu-20-04, build-1-7-7-ubuntu-18-04, build-1-7-7-virtualbox-6-1-28-ubuntu-18-04]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dockerized [`packer`](https://github.com/hashicorp/packer) with useful tools.
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
 | `:1.7.7-ubuntu-20.04`, `:latest` | [View](variants/1.7.7-ubuntu-20.04 ) |
-| `:1.7.7-virtualbox-ubuntu-20.04` | [View](variants/1.7.7-virtualbox-ubuntu-20.04 ) |
+| `:1.7.7-virtualbox-6.1.28-ubuntu-20.04` | [View](variants/1.7.7-virtualbox-6.1.28-ubuntu-20.04 ) |
 | `:1.7.7-ubuntu-18.04` | [View](variants/1.7.7-ubuntu-18.04 ) |
-| `:1.7.7-virtualbox-ubuntu-18.04` | [View](variants/1.7.7-virtualbox-ubuntu-18.04 ) |
+| `:1.7.7-virtualbox-6.1.28-ubuntu-18.04` | [View](variants/1.7.7-virtualbox-6.1.28-ubuntu-18.04 ) |
 

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -8,7 +8,7 @@ $local:VARIANTS_MATRIX = @(
         distro_version = '20.04'
         subvariants = @(
             @{ components = @(); tag_as_latest = $true }
-            @{ components = @( 'virtualbox' ) }
+            @{ components = @( 'virtualbox-6.1.28' ) }
         )
     }
     @{
@@ -18,7 +18,7 @@ $local:VARIANTS_MATRIX = @(
         distro_version = '18.04'
         subvariants = @(
             @{ components = @() }
-            @{ components = @( 'virtualbox' ) }
+            @{ components = @( 'virtualbox-6.1.28' ) }
         )
     }
 )

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -85,12 +85,18 @@ RUN apt-get update \
 "@
         }
 
-        'virtualbox' {
+        'virtualbox-6.1.28' {
                 @"
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y virtualbox \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Install virtualbox using .deb installer instead of apt
+# Virtualbox: https://www.virtualbox.org/wiki/Linux_Downloads
+RUN wget -qO- https://download.virtualbox.org/virtualbox/6.1.28/virtualbox-6.1_6.1.28-147628~Ubuntu~eoan_amd64.deb > /root/virtualbox.deb \
+    && sha256sum /root/virtualbox.deb | grep e3078f3a1af0e8692acaa37587d46a33ee17b490110c2491bd9179938822d7be \
+    && apt-get install -y /root/virtualbox.deb \
+    && rm -f /root/virtualbox.deb
+# RUN apt-get update \
+#     && apt-get install --no-install-recommends -y virtualbox \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 # Not GPL, must accept terms. See: https://www.virtualbox.org/wiki/Licensing_FAQ
 # RUN apt-get update \

--- a/variants/1.7.7-virtualbox-6.1.28-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-6.1.28-ubuntu-18.04/Dockerfile
@@ -55,10 +55,16 @@ RUN apt-get update \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y virtualbox \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Install virtualbox using .deb installer instead of apt
+# Virtualbox: https://www.virtualbox.org/wiki/Linux_Downloads
+RUN wget -qO- https://download.virtualbox.org/virtualbox/6.1.28/virtualbox-6.1_6.1.28-147628~Ubuntu~eoan_amd64.deb > /root/virtualbox.deb \
+    && sha256sum /root/virtualbox.deb | grep e3078f3a1af0e8692acaa37587d46a33ee17b490110c2491bd9179938822d7be \
+    && apt-get install -y /root/virtualbox.deb \
+    && rm -f /root/virtualbox.deb
+# RUN apt-get update \
+#     && apt-get install --no-install-recommends -y virtualbox \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 # Not GPL, must accept terms. See: https://www.virtualbox.org/wiki/Licensing_FAQ
 # RUN apt-get update \

--- a/variants/1.7.7-virtualbox-6.1.28-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-virtualbox-6.1.28-ubuntu-20.04/Dockerfile
@@ -55,10 +55,16 @@ RUN apt-get update \
     && chmod +x /usr/local/bin/mc \
     && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y virtualbox \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Install virtualbox using .deb installer instead of apt
+# Virtualbox: https://www.virtualbox.org/wiki/Linux_Downloads
+RUN wget -qO- https://download.virtualbox.org/virtualbox/6.1.28/virtualbox-6.1_6.1.28-147628~Ubuntu~eoan_amd64.deb > /root/virtualbox.deb \
+    && sha256sum /root/virtualbox.deb | grep e3078f3a1af0e8692acaa37587d46a33ee17b490110c2491bd9179938822d7be \
+    && apt-get install -y /root/virtualbox.deb \
+    && rm -f /root/virtualbox.deb
+# RUN apt-get update \
+#     && apt-get install --no-install-recommends -y virtualbox \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 # Not GPL, must accept terms. See: https://www.virtualbox.org/wiki/Licensing_FAQ
 # RUN apt-get update \


### PR DESCRIPTION
Closes #10

Previously, `apt` was used to install `virtualbox`. Although this means builds are less error prone and should work, it has downsides:
- images version of `virtualbox` will mutate over time along with the upstream `apt` package
- unknown and unpredictable `virtualbox` version in docker images
- different `virtualbox` versions among distro variants e.g. `apt` package on ubuntu 18.04 was `virtualbox` 5, whereas `apt` package on ubuntu 20.04 was `virtualbox` 6

Now a specific version of `virtualbox` is installed by using official `.deb` pacakges. This keeps reliability of builds, while addressing all of above weaknesses.