### PR TITLE
Refactor: Install `virtualbox` from `.deb` file instead of `apt`

### DIFF
--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -1,54 +1,46 @@
 
 # Docker image variants' definitions
-$local:VARIANTS_MATRIX = @(
-    @{
-        package = 'packer'
-        package_version = '1.7.7'
-        distro = 'ubuntu'
-        distro_version = '20.04'
-        subvariants = @(
-            @{ components = @( 'sops' ); tag_as_latest = $true }
-            @{ components = @( 'sops', 'virtualbox-6.1' ) }
-        )
-    }
-    @{
-        package = 'packer'
-        package_version = '1.7.7'
-        distro = 'ubuntu'
-        distro_version = '18.04'
-        subvariants = @(
-            @{ components = @( 'sops' ) }
-            @{ components = @( 'sops', 'virtualbox-6.1' ) }
-        )
-    }
-)
-
 $VARIANTS = @(
-    foreach ($variant in $VARIANTS_MATRIX){
-        foreach ($subVariant in $variant['subvariants']) {
-            @{
-                # Metadata object
-                _metadata = @{
-                    package_version = $variant['package_version']
-                    distro = $variant['distro']
-                    distro_version = $variant['distro_version']
-                    platforms = 'linux/amd64'
-                    components = $subVariant['components']
-                }
-                # Docker image tag. E.g. '1.7.7-virtualbox-ubuntu-18.04'
-                tag = @(
-                        $variant['package_version']
-                        $subVariant['components'] | ? { $_ }
-                        $variant['distro']
-                        $variant['distro_version']
-                ) -join '-'
-                tag_as_latest = if ( $subVariant.Contains('tag_as_latest') ) {
-                                    $subVariant['tag_as_latest']
-                                } else {
-                                    $false
-                                }
-            }
+    @{
+        _metadata = @{
+            package_version = '1.7.7'
+            distro = 'ubuntu'
+            distro_version = '20.04'
+            platforms = 'linux/amd64'
+            components = @( 'sops' )
         }
+        tag = '1.7.7-sops-ubuntu-20.04'
+        tag_as_latest = $true
+    }
+    @{
+        _metadata = @{
+            package_version = '1.7.7'
+            distro = 'ubuntu'
+            distro_version = '20.04'
+            platforms = 'linux/amd64'
+            components = @( 'sops', 'virtualbox-6.1.26' )
+        }
+        tag = '1.7.7-sops-virtualbox-6.1-ubuntu-20.04'
+    }
+    @{
+        _metadata = @{
+            package_version = '1.7.7'
+            distro = 'ubuntu'
+            distro_version = '18.04'
+            platforms = 'linux/amd64'
+            components = @( 'sops' )
+        }
+        tag = '1.7.7-sops-ubuntu-18.04'
+    }
+    @{
+        _metadata = @{
+            package_version = '1.7.7'
+            distro = 'ubuntu'
+            distro_version = '18.04'
+            platforms = 'linux/amd64'
+            components = @( 'sops', 'virtualbox-6.1.26' )
+        }
+        tag = '1.7.7-sops-virtualbox-6.1-ubuntu-18.04'
     }
 )
 
@@ -58,8 +50,6 @@ $VARIANTS_SHARED = @{
         templates = @{
             'Dockerfile' = @{
                 common = $true
-                includeHeader = $false
-                includeFooter = $false
                 passes = @(
                     @{
                         variables = @{}

--- a/variants/1.7.7-sops-virtualbox-6.1-ubuntu-18.04/Dockerfile
+++ b/variants/1.7.7-sops-virtualbox-6.1-ubuntu-18.04/Dockerfile
@@ -34,19 +34,26 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Virtualbox: https://www.virtualbox.org/wiki/Linux_Downloads
-RUN buildDeps="gnupg2 wget software-properties-common" \
+# Dynamically determine the package, using the SHA256SUMS file, because there is a 5 digit number suffix in the version that is unknown
+# E.g. https://download.virtualbox.org/virtualbox/6.1.22/virtualbox-6.1_6.1.22-144080~Ubuntu~eoan_amd64.deb
+RUN export DEBIAN_FRONTEND=noninteractive \
+    buildDeps="curl build-essential dkms" \
     && apt-get update \
     && apt-get install --no-install-recommends -y $buildDeps \
-    && wget -qO- https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - \
-    && wget -qO- https://www.virtualbox.org/download/oracle_vbox.asc | apt-key add - \
-    && apt-add-repository "deb [arch=amd64] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" \
-    && apt-get update \
-    && apt-get install --no-install-recommends -y virtualbox-6.1 \
+    && curl -sSLO "https://download.virtualbox.org/virtualbox/6.1.26/SHA256SUMS" \
+    && FILE="$( cat SHA256SUMS | grep 'Ubuntu~bionic_amd64.deb' | awk '{print $2}' | cut -d '*' -f2 )" \
+    && PACKAGE="https://download.virtualbox.org/virtualbox/6.1.26/$FILE" \
+    && curl -sSLO "$PACKAGE" \
+    && cat SHA256SUMS | grep "$FILE" | sha256sum -c \
+    && apt-get install --no-install-recommends -y "./$FILE" \
+    && vboxmanage --version \
+    && rm -f "$FILE" \
     && apt-get purge --auto-remove -y $buildDeps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Virtualbox extension pack: https://www.virtualbox.org/wiki/Downloads
+# E.g. https://download.virtualbox.org/virtualbox/6.1.22/Oracle_VM_VirtualBox_Extension_Pack-6.1.22.vbox-extpack
 # Not GPL, must accept terms. See: https://www.virtualbox.org/wiki/Licensing_FAQ
 # RUN apt-get update \
 # && apt-get install --no-install-recommends -y virtualbox-ext-pack \

--- a/variants/1.7.7-sops-virtualbox-6.1-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-sops-virtualbox-6.1-ubuntu-20.04/Dockerfile
@@ -34,19 +34,26 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Virtualbox: https://www.virtualbox.org/wiki/Linux_Downloads
-RUN buildDeps="gnupg2 wget software-properties-common" \
+# Dynamically determine the package, using the SHA256SUMS file, because there is a 5 digit number suffix in the version that is unknown
+# E.g. https://download.virtualbox.org/virtualbox/6.1.22/virtualbox-6.1_6.1.22-144080~Ubuntu~eoan_amd64.deb
+RUN export DEBIAN_FRONTEND=noninteractive \
+    buildDeps="curl build-essential dkms" \
     && apt-get update \
     && apt-get install --no-install-recommends -y $buildDeps \
-    && wget -qO- https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - \
-    && wget -qO- https://www.virtualbox.org/download/oracle_vbox.asc | apt-key add - \
-    && apt-add-repository "deb [arch=amd64] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" \
-    && apt-get update \
-    && apt-get install --no-install-recommends -y virtualbox-6.1 \
+    && curl -sSLO "https://download.virtualbox.org/virtualbox/6.1.26/SHA256SUMS" \
+    && FILE="$( cat SHA256SUMS | grep 'Ubuntu~eoan_amd64.deb' | awk '{print $2}' | cut -d '*' -f2 )" \
+    && PACKAGE="https://download.virtualbox.org/virtualbox/6.1.26/$FILE" \
+    && curl -sSLO "$PACKAGE" \
+    && cat SHA256SUMS | grep "$FILE" | sha256sum -c \
+    && apt-get install --no-install-recommends -y "./$FILE" \
+    && vboxmanage --version \
+    && rm -f "$FILE" \
     && apt-get purge --auto-remove -y $buildDeps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Virtualbox extension pack: https://www.virtualbox.org/wiki/Downloads
+# E.g. https://download.virtualbox.org/virtualbox/6.1.22/Oracle_VM_VirtualBox_Extension_Pack-6.1.22.vbox-extpack
 # Not GPL, must accept terms. See: https://www.virtualbox.org/wiki/Licensing_FAQ
 # RUN apt-get update \
 # && apt-get install --no-install-recommends -y virtualbox-ext-pack \


### PR DESCRIPTION
As discussed in https://github.com/theohbrothers/docker-packer/issues/10#issuecomment-968289857, it is better to install `virtualbox` using a `.deb` rather than `apt`. Benefits
- builds are atomic
- images contain distinct `virtualbox` version
- host can consume images matching its `virtualbox` version