### PR TITLE
Refactor: Rename `virtualbox` variants from `virtualbox-6.1` to `virtualbox-6.1.xx`

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -138,11 +138,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-1-7-7-sops-virtualbox-6-1-ubuntu-20-04:
+  build-1-7-7-sops-virtualbox-6-1-26-ubuntu-20-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 1.7.7-sops-virtualbox-6.1-ubuntu-20.04
-      VARIANT_BUILD_DIR: variants/1.7.7-sops-virtualbox-6.1-ubuntu-20.04
+      VARIANT_TAG: 1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04
+      VARIANT_BUILD_DIR: variants/1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -265,7 +265,7 @@ jobs:
       if: always()
 
   update-draft-release:
-    needs: [build-1-7-7-sops-ubuntu-20-04, build-1-7-7-sops-virtualbox-6-1-ubuntu-20-04]
+    needs: [build-1-7-7-sops-ubuntu-20-04, build-1-7-7-sops-virtualbox-6-1-26-ubuntu-20-04]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -278,7 +278,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-1-7-7-sops-ubuntu-20-04, build-1-7-7-sops-virtualbox-6-1-ubuntu-20-04]
+    needs: [build-1-7-7-sops-ubuntu-20-04, build-1-7-7-sops-virtualbox-6-1-26-ubuntu-20-04]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,26 @@ Dockerized [`packer`](https://github.com/hashicorp/packer) with useful tools.
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
 | `:1.7.7-sops-ubuntu-20.04`, `:latest` | [View](variants/1.7.7-sops-ubuntu-20.04 ) |
-| `:1.7.7-sops-virtualbox-6.1-ubuntu-20.04` | [View](variants/1.7.7-sops-virtualbox-6.1-ubuntu-20.04 ) |
+| `:1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04` | [View](variants/1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04 ) |
+
+
+## Usage
+
+
+```sh
+docker run --rm -it \
+    -v $(pwd):/src \
+    -w /src \
+    theohbrothers/docker-packer:1.7.7-sops-ubuntu-20.04 sh -c 'packer --version && packer build .'
+
+# virtualbox
+# The host must have an exact matching virtualbox version, in this case, virtualbox 6.1.26
+docker run --rm -it \
+    -v /dev/vboxdrv:/dev/vboxdrv:ro \
+    -v $(pwd):/src \
+    -w /src \
+    theohbrothers/docker-packer:1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04 sh -c 'packer --version && vboxmanage --version && packer build .'
+```
 
 ## Development
 

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -1,26 +1,44 @@
 
 # Docker image variants' definitions
-$VARIANTS = @(
+$local:VARIANTS_MATRIX = @(
     @{
-        _metadata = @{
-            package_version = '1.7.7'
-            distro = 'ubuntu'
-            distro_version = '20.04'
-            platforms = 'linux/amd64'
-            components = @( 'sops' )
-        }
-        tag = '1.7.7-sops-ubuntu-20.04'
-        tag_as_latest = $true
+        package = 'packer'
+        package_version = '1.7.7'
+        distro = 'ubuntu'
+        distro_version = '20.04'
+        subvariants = @(
+            @{ components = @( 'sops' ); tag_as_latest = $true }
+            @{ components = @( 'sops', 'virtualbox-6.1.26' ) }
+        )
     }
-    @{
-        _metadata = @{
-            package_version = '1.7.7'
-            distro = 'ubuntu'
-            distro_version = '20.04'
-            platforms = 'linux/amd64'
-            components = @( 'sops', 'virtualbox-6.1.26' )
+)
+
+$VARIANTS = @(
+    foreach ($variant in $VARIANTS_MATRIX){
+        foreach ($subVariant in $variant['subvariants']) {
+            @{
+                # Metadata object
+                _metadata = @{
+                    package_version = $variant['package_version']
+                    distro = $variant['distro']
+                    distro_version = $variant['distro_version']
+                    platforms = 'linux/amd64'
+                    components = $subVariant['components']
+                }
+                # Docker image tag. E.g. '1.7.7-virtualbox-ubuntu-18.04'
+                tag = @(
+                        $variant['package_version']
+                        $subVariant['components'] | ? { $_ }
+                        $variant['distro']
+                        $variant['distro_version']
+                ) -join '-'
+                tag_as_latest = if ( $subVariant.Contains('tag_as_latest') ) {
+                                    $subVariant['tag_as_latest']
+                                } else {
+                                    $false
+                                }
+            }
         }
-        tag = '1.7.7-sops-virtualbox-6.1-ubuntu-20.04'
     }
 )
 
@@ -30,6 +48,8 @@ $VARIANTS_SHARED = @{
         templates = @{
             'Dockerfile' = @{
                 common = $true
+                includeHeader = $false
+                includeFooter = $false
                 passes = @(
                     @{
                         variables = @{}

--- a/generate/templates/README.md.ps1
+++ b/generate/templates/README.md.ps1
@@ -28,7 +28,27 @@ $(
 )
 
 "@
+
 @'
+
+## Usage
+
+
+```sh
+docker run --rm -it \
+    -v $(pwd):/src \
+    -w /src \
+    theohbrothers/docker-packer:1.7.7-sops-ubuntu-20.04 sh -c 'packer --version && packer build .'
+
+# virtualbox
+# The host must have an exact matching virtualbox version, in this case, virtualbox 6.1.26
+docker run --rm -it \
+    -v /dev/vboxdrv:/dev/vboxdrv:ro \
+    -v $(pwd):/src \
+    -w /src \
+    theohbrothers/docker-packer:1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04 sh -c 'packer --version && vboxmanage --version && packer build .'
+```
+
 ## Development
 
 Requires Windows `powershell` or [`pwsh`](https://github.com/PowerShell/PowerShell).

--- a/variants/1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04/Dockerfile
+++ b/variants/1.7.7-sops-virtualbox-6.1.26-ubuntu-20.04/Dockerfile
@@ -1,0 +1,98 @@
+FROM ubuntu:20.04
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Disable packer checkpoints. See: https://www.packer.io/docs/configure#full-list-of-environment-variables-usable-for-packer
+ENV CHECKPOINT_DISABLE=1
+
+# Install packer
+RUN buildDeps="gnupg2 curl software-properties-common" \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y $buildDeps \
+    && curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y packer=1.7.7 \
+    && apt-get purge --auto-remove -y $buildDeps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install sops, gpg for sops
+RUN buildDeps="wget" \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y $buildDeps \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops \
+    && chmod +x /usr/local/bin/sops \
+    && sha256sum /usr/local/bin/sops | grep 185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 \
+    && apt-get purge --auto-remove -y $buildDeps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y gnupg2 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Virtualbox: https://www.virtualbox.org/wiki/Linux_Downloads
+# Dynamically determine the package, using the SHA256SUMS file, because there is a 5 digit number suffix in the version that is unknown
+# E.g. https://download.virtualbox.org/virtualbox/6.1.22/virtualbox-6.1_6.1.22-144080~Ubuntu~eoan_amd64.deb
+RUN export DEBIAN_FRONTEND=noninteractive \
+    buildDeps="curl build-essential dkms" \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y $buildDeps \
+    && curl -sSLO "https://download.virtualbox.org/virtualbox/6.1.26/SHA256SUMS" \
+    && FILE="$( cat SHA256SUMS | grep 'Ubuntu~eoan_amd64.deb' | awk '{print $2}' | cut -d '*' -f2 )" \
+    && PACKAGE="https://download.virtualbox.org/virtualbox/6.1.26/$FILE" \
+    && curl -sSLO "$PACKAGE" \
+    && cat SHA256SUMS | grep "$FILE" | sha256sum -c \
+    && apt-get install --no-install-recommends -y "./$FILE" \
+    && vboxmanage --version \
+    && rm -f "$FILE" \
+    && apt-get purge --auto-remove -y $buildDeps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Virtualbox extension pack: https://www.virtualbox.org/wiki/Downloads
+# E.g. https://download.virtualbox.org/virtualbox/6.1.22/Oracle_VM_VirtualBox_Extension_Pack-6.1.22.vbox-extpack
+# Not GPL, must accept terms. See: https://www.virtualbox.org/wiki/Licensing_FAQ
+# RUN apt-get update \
+# && apt-get install --no-install-recommends -y virtualbox-ext-pack \
+# && apt-get clean \
+# && rm -rf /var/lib/apt/lists/*
+
+# Install basic tools
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y sudo ca-certificates wget curl git rsync \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tools for .vhd, .vmdk
+# Fix apt dialog: https://github.com/moby/moby/issues/27988#issuecomment-462809153
+# Fix guestmount error 'supermin: failed to find a suitable kernel (host_cpu=x86_64)': https://github.com/steigr/docker-hipchat-server/issues/1
+RUN apt-get update \
+    \
+    && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
+    && apt-get install --no-install-recommends -y libguestfs-tools \
+    \
+    && apt-get install --no-install-recommends -y linux-image-generic \
+    \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tools for .iso
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y sudo isolinux squashfs-tools xorriso mkisofs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tools for storage
+# s3fs: https://github.com/s3fs-fuse/s3fs-fuse
+# mc: https://min.io/download#/linux
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y s3fs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && wget -qO- https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-10-07T04-19-58Z > /usr/local/bin/mc \
+    && chmod +x /usr/local/bin/mc \
+    && sha256sum /usr/local/bin/mc | grep aa58e16c74c38bc05ecf73bedee476eafb3a1c42ea1ac95635853b530a36be93


### PR DESCRIPTION
This will allow us to build `virtualbox` variants tagged after `virtualbox` versions.