### PR TITLE
Docs: Use `2` cpu and `1024M` in `ubuntu2004-qemu` example

### DIFF
--- a/docs/ubuntu2004-qemu/README.md
+++ b/docs/ubuntu2004-qemu/README.md
@@ -4,7 +4,7 @@ This example builds an Ubuntu 20.04 VM image using the [QEMU builder](https://de
 
 ```sh
 # 1. Build
-docker run --rm --privileged -it -v $(pwd):/src -p 127.0.0.1:5901:5901 -w /src -e PACKER_LOG=1 theohbrothers/docker-packer:1.7.7-sops-qemu-ubuntu-20.04 packer build template.json
+docker run --rm -it --privileged -v $(pwd):/src -w /src -p 127.0.0.1:5901:5901 -e PACKER_LOG=1 theohbrothers/docker-packer:1.7.7-sops-qemu-ubuntu-20.04 packer build template.json
 
 # 2. During the build, to connect to the VM's console from the host
 vncviewer -Shared 127.0.0.1:5901

--- a/docs/ubuntu2004-qemu/template.json
+++ b/docs/ubuntu2004-qemu/template.json
@@ -8,7 +8,6 @@
       ],
       "iso_checksum": "sha256:5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4",
       "output_directory": "build",
-      "shutdown_command": "echo 'ubuntu' | sudo -S shutdown -P now",
       "disk_size": "8192M",
       "format": "qcow2",
       "disk_cache": "none",
@@ -18,7 +17,6 @@
       "vm_name": "ubuntu2004-qemu.qcow2",
       "net_device": "virtio-net",
       "disk_interface": "virtio",
-      "boot_wait": "1s",
       "vnc_bind_address": "0.0.0.0",
       "vnc_port_min": "5901",
       "vnc_port_max": "5901",
@@ -27,10 +25,11 @@
       "ssh_password": "ubuntu",
       "ssh_timeout": "1h",
       "ssh_handshake_attempts": "99999",
+      "boot_wait": "1s",
       "boot_keygroup_interval": "1s",
       "qemuargs": [
-        ["-m", "2048M"],
-        ["-smp", "4"],
+        ["-m", "1024M"],
+        ["-smp", "2"],
         ["-netdev", "user,hostfwd=tcp::{{ .SSHHostPort }}-:22,id=forward"],
         ["-device", "virtio-net,netdev=forward,id=net0"]
       ],
@@ -50,7 +49,8 @@
         "/casper/vmlinuz autoinstall quiet net.ifnames=0 biosdevname=0 ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
         "initrd=/casper/initrd ",
         " --- <enter>"
-      ]
+      ],
+      "shutdown_command": "echo 'ubuntu' | sudo -S shutdown -P now"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
`subiquity` `curtin` will fail with an error if any lower than `2` CPUs are allocated. `1024M` of RAM is sufficient.
